### PR TITLE
Tiny memory leak in tag families implementation

### DIFF
--- a/tag16h5.c
+++ b/tag16h5.c
@@ -111,5 +111,6 @@ void tag16h5_destroy(apriltag_family_t *tf)
    free(tf->codes);
    free(tf->bit_x);
    free(tf->bit_y);
+   free(tf->name);
    free(tf);
 }

--- a/tag25h9.c
+++ b/tag25h9.c
@@ -134,5 +134,6 @@ void tag25h9_destroy(apriltag_family_t *tf)
    free(tf->codes);
    free(tf->bit_x);
    free(tf->bit_y);
+   free(tf->name);
    free(tf);
 }

--- a/tag36h11.c
+++ b/tag36h11.c
@@ -708,5 +708,6 @@ void tag36h11_destroy(apriltag_family_t *tf)
    free(tf->codes);
    free(tf->bit_x);
    free(tf->bit_y);
+   free(tf->name);
    free(tf);
 }

--- a/tagCircle21h7.c
+++ b/tagCircle21h7.c
@@ -129,5 +129,6 @@ void tagCircle21h7_destroy(apriltag_family_t *tf)
    free(tf->codes);
    free(tf->bit_x);
    free(tf->bit_y);
+   free(tf->name);
    free(tf);
 }

--- a/tagCircle49h12.c
+++ b/tagCircle49h12.c
@@ -65845,5 +65845,6 @@ void tagCircle49h12_destroy(apriltag_family_t *tf)
    free(tf->codes);
    free(tf->bit_x);
    free(tf->bit_y);
+   free(tf->name);
    free(tf);
 }

--- a/tagCustom48h12.c
+++ b/tagCustom48h12.c
@@ -42356,5 +42356,6 @@ void tagCustom48h12_destroy(apriltag_family_t *tf)
    free(tf->codes);
    free(tf->bit_x);
    free(tf->bit_y);
+   free(tf->name);
    free(tf);
 }

--- a/tagStandard41h12.c
+++ b/tagStandard41h12.c
@@ -2246,5 +2246,6 @@ void tagStandard41h12_destroy(apriltag_family_t *tf)
    free(tf->codes);
    free(tf->bit_x);
    free(tf->bit_y);
+   free(tf->name);
    free(tf);
 }

--- a/tagStandard52h13.c
+++ b/tagStandard52h13.c
@@ -48867,5 +48867,6 @@ void tagStandard52h13_destroy(apriltag_family_t *tf)
    free(tf->codes);
    free(tf->bit_x);
    free(tf->bit_y);
+   free(tf->name);
    free(tf);
 }


### PR DESCRIPTION
There is code 
`tf->name = strdup("tag25h9");`
in each tag family implementation. According to specification of `strdup` function (https://en.cppreference.com/w/c/experimental/dynamic/strdup) the pointer returned by it should be freed by user of the function. But tag_family_destroy does not do it. It leads to tiny memory leak (about 9 byte each) but still.
I assume that those changes should be done also in generator of families implementation.