### PR TITLE
Check for NULL before calling matd_destroy

### DIFF
--- a/apriltag_pose.c
+++ b/apriltag_pose.c
@@ -517,8 +517,10 @@ double estimate_tag_pose(apriltag_detection_info_t* info, apriltag_pose_t* pose)
     if (err1 <= err2) {
         pose->R = pose1.R;
         pose->t = pose1.t;
+        if (pose2.R) {
+            matd_destroy(pose2.t);
+        }
         matd_destroy(pose2.R);
-        matd_destroy(pose2.t);
         return err1;
     } else {
         pose->R = pose2.R;


### PR DESCRIPTION
`pose2.R` is initialized only if there is one new minima:
https://github.com/AprilRobotics/apriltags/blob/a5ab81dd79fd294b77940efad889a820509e83ae/apriltag_pose.c#L412-L426

`pose2.t` is initialized only if `pose2.R` is not `NULL`:
https://github.com/AprilRobotics/apriltags/blob/a5ab81dd79fd294b77940efad889a820509e83ae/apriltag_pose.c#L496-L502

Probably should fix #22 